### PR TITLE
Refactor helpers and add UI extension upload support

### DIFF
--- a/CheckMacrosOnAllSystems.ps1
+++ b/CheckMacrosOnAllSystems.ps1
@@ -1,109 +1,75 @@
 # Source helper functions
 . .\HelperFunctions.ps1
 
-# Function to log messages to a file
-function Log-Message {
-    param (
-        [string]$message,
-        [string]$logFile
-    )
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp - $message"
-    Add-Content -Path $logFile -Value $logEntry
-}
-
-# Function to display messages in the console
-function Display-Message {
-    param (
-        [string]$message
-    )
-    Write-Host $message
-}
-
 # Initialize log file
 $logFile = "CheckMacrosOnAllSystems.log"
 
 Display-Message "Option 5 selected: Check macros on all systems"
-Log-Message -message "Option 5 selected: Check macros on all systems" -logFile $logFile
+Log-Message -Message "Option 5 selected: Check macros on all systems" -LogFile $logFile
 
 # Prompt user for CSV file path
 $csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CSV file:"
 
 # Import CSV
 try {
-    $systems = @(Import-Csv -Path $csvFilePath)
-    if ($systems -eq $null -or $systems.Count -eq 0) {
-        throw "CSV file is empty or improperly formatted."
-    }
+    $systems = Import-SystemCsv -Path $csvFilePath
     Display-Message "Found $($systems.Count) systems in the CSV file."
-    Log-Message -message "Found $($systems.Count) systems in the CSV file." -logFile $logFile
+    Log-Message -Message "Found $($systems.Count) systems in the CSV file." -LogFile $logFile
 } catch {
     $errorDetails = $_.Exception.Message
     Display-Message "Error importing CSV file. Response: $errorDetails"
-    Log-Message -message "Error importing CSV file. Response: $errorDetails" -logFile $logFile
+    Log-Message -Message "Error importing CSV file. Response: $errorDetails" -LogFile $logFile
     return
 }
 
 # Confirm check
 if (-not (Get-Confirmation -promptMessage "Do you want to proceed with checking macros on all systems?")) {
     Display-Message "Check cancelled."
-    Log-Message -message "Check cancelled." -logFile $logFile
+    Log-Message -Message "Check cancelled." -LogFile $logFile
     return
 }
 
-# Function to get macros from a system
-function Get-Macros {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to get macros from $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Content-Type", "application/xml")
-    $headers.Add("Authorization", "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}")))
-
-    $body = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Get/>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://${endpointIp}/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        [xml]$xmlResponse = $response
-        $macros = $xmlResponse.Command.MacroGetResult.Macro | ForEach-Object { $_.Name }
-        if ($macros.Count -gt 0) {
-            $message = "The following macros were found on ${endpointIp} ($systemName): $($macros -join ', ')"
-        } else {
-            $message = "No macros found on ${endpointIp} ($systemName)."
-        }
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error getting macros from ${endpointIp} ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    }
-}
-
 # Perform the check
+$checkResults = @()
+
 foreach ($system in $systems) {
     $systemName = $system.'system name'
     $ipAddress = $system.'ip address'
     $username = $system.'username'
     $password = $system.'password'
 
-    Get-Macros -endpointIp $ipAddress -username $username -password $password -logFile $logFile -systemName $systemName
+    $macros = Get-SystemMacros -EndpointIp $ipAddress -Username $username -Password $password -LogFile $logFile -SystemName $systemName
+
+    if ($macros.Count -gt 0) {
+        $message = "The following macros were found on ${ipAddress} ($systemName): $($macros -join ', ')"
+    } else {
+        $message = "No macros found on ${ipAddress} ($systemName)."
+    }
+
+    Display-Message $message
+    Log-Message -Message $message -LogFile $logFile
+
+    $checkResults += [PSCustomObject]@{
+        IPAddress  = $ipAddress
+        SystemName = $systemName
+        Macros     = if ($macros.Count -gt 0) { $macros -join '; ' } else { '<None>' }
+    }
+}
+
+Display-Message "Macro check completed."
+Log-Message -Message "Macro check completed." -LogFile $logFile
+
+if (Get-Confirmation -promptMessage "Would you like to export the results to a CSV file?") {
+    $exportPath = Get-FilePath -promptMessage "Enter the full path for the export CSV file:"
+    try {
+        $checkResults | Export-Csv -Path $exportPath -NoTypeInformation
+        $message = "Results exported to $exportPath"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $logFile
+    } catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Failed to export results. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $logFile
+    }
 }

--- a/CheckMacrosOnSystem.ps1
+++ b/CheckMacrosOnSystem.ps1
@@ -1,82 +1,45 @@
 # Source helper functions
 . .\HelperFunctions.ps1
 
-# Function to log messages to a file
-function Log-Message {
-    param (
-        [string]$message,
-        [string]$logFile
-    )
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp - $message"
-    Add-Content -Path $logFile -Value $logEntry
-}
-
-# Function to display messages in the console
-function Display-Message {
-    param (
-        [string]$message
-    )
-    Write-Host $message
-}
-
 # Initialize log file
 $logFile = "CheckMacrosOnSystem.log"
 
 Display-Message "Option 4 selected: Check macros on a specific system"
-Log-Message -message "Option 4 selected: Check macros on a specific system" -logFile $logFile
+Log-Message -Message "Option 4 selected: Check macros on a specific system" -LogFile $logFile
 
 # Prompt user for system details
 $endpointIp = Read-Host "Please enter the IP address of the system"
 $username = Read-Host "Please enter the username"
 $password = Read-Host "Please enter the password" -AsSecureString
-$passwordPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($password))
+$passwordPlain = ConvertTo-PlainText -SecureString $password
 
-# Function to get macros from a single system
-function Get-Macros {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile
-    )
+$macros = Get-SystemMacros -EndpointIp $endpointIp -Username $username -Password $passwordPlain -LogFile $logFile -SystemName $endpointIp
 
-    $message = "Attempting to get macros from $endpointIp..."
+if ($macros.Count -gt 0) {
+    $message = "The following macros were found on ${endpointIp}: $($macros -join ', ')"
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Content-Type", "application/xml")
-    $headers.Add("Authorization", "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}")))
-
-    $body = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Get/>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://${endpointIp}/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        [xml]$xmlResponse = $response
-        $macros = $xmlResponse.Command.MacroGetResult.Macro | ForEach-Object { $_.Name }
-        if ($macros.Count -gt 0) {
-            $message = "The following macros were found on ${endpointIp}: $($macros -join ', ')"
-        } else {
-            $message = "No macros found on ${endpointIp}."
-        }
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error getting macros from ${endpointIp}. Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    }
+    Log-Message -Message $message -LogFile $logFile
+} else {
+    $message = "No macros found on ${endpointIp}."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $logFile
 }
 
-# Perform the check
-Get-Macros -endpointIp $endpointIp -username $username -password $passwordPlain -logFile $logFile
+if (Get-Confirmation -promptMessage "Would you like to export the results to a CSV file?") {
+    $exportPath = Get-FilePath -promptMessage "Enter the full path for the export CSV file:"
+    try {
+        $exportData = $macros | ForEach-Object { [PSCustomObject]@{ IPAddress = $endpointIp; Username = $username; Macro = $_ } }
+        if ($exportData.Count -eq 0) {
+            $exportData = [PSCustomObject]@{ IPAddress = $endpointIp; Username = $username; Macro = "<None>" }
+        }
+        $exportData | Export-Csv -Path $exportPath -NoTypeInformation
+        $message = "Results exported to $exportPath"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $logFile
+    } catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Failed to export results. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $logFile
+    }
+}

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -7,19 +7,113 @@ function Get-FilePath {
     return Read-Host
 }
 
-# Function to get the list of macros currently on the system
-function Get-Macros {
+# Function to log messages to a file
+function Log-Message {
     param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password
+        [string]$Message,
+        [string]$LogFile
     )
 
-    Write-Host "Attempting to connect to $endpointIp..."
+    if (-not [string]::IsNullOrWhiteSpace($LogFile)) {
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        $logEntry = "$timestamp - $Message"
+        Add-Content -Path $LogFile -Value $logEntry
+    }
+}
 
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Content-Type", "application/xml")
-    $headers.Add("Authorization", "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}")))
+# Function to display messages in the console
+function Display-Message {
+    param (
+        [string]$Message
+    )
+    Write-Host $Message
+}
+
+# Function to prompt user for confirmation
+function Get-Confirmation {
+    param (
+        [string]$promptMessage
+    )
+    Write-Host "$promptMessage (y/n)"
+    $response = Read-Host
+    return $response -eq 'y'
+}
+
+# Function to import systems from CSV with validation
+function Import-SystemCsv {
+    param (
+        [string]$Path
+    )
+
+    $systems = @(Import-Csv -Path $Path)
+    if ($systems -eq $null -or $systems.Count -eq 0) {
+        throw "CSV file is empty or improperly formatted."
+    }
+
+    return $systems
+}
+
+# Convert secure string to plain text
+function ConvertTo-PlainText {
+    param (
+        [System.Security.SecureString]$SecureString
+    )
+
+    if ($null -eq $SecureString) {
+        return [string]::Empty
+    }
+
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+# Build common headers for Cisco xAPI requests
+function New-CiscoXapiHeader {
+    param (
+        [string]$Username,
+        [string]$Password
+    )
+
+    return @{
+        "Content-Type"  = "application/xml"
+        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${Username}:${Password}"))
+    }
+}
+
+# Wrapper for Invoke-RestMethod calls to Cisco endpoints
+function Invoke-CiscoXapiRequest {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [object]$Body,
+        [int]$TimeoutSec = 15
+    )
+
+    $headers = New-CiscoXapiHeader -Username $Username -Password $Password
+
+    return Invoke-RestMethod -Uri "https://$EndpointIp/putxml" -Method 'POST' -Headers $headers -Body $Body -TimeoutSec $TimeoutSec -SkipCertificateCheck -ErrorAction Stop
+}
+
+# Retrieve macros available on a system
+function Get-SystemMacros {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to get macros from $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
 
     $body = @"
 <Command>
@@ -32,23 +126,373 @@ function Get-Macros {
 "@
 
     try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        $xmlContent = [xml]$response
-        $macros = $xmlContent.Command.MacroGetResult.Macro | ForEach-Object { $_.Name }
-        return $macros
-    } catch {
+        $response = Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body -TimeoutSec 10
+        $xmlResponse = [xml]$response
+        $macros = $xmlResponse.Command.MacroGetResult.Macro | ForEach-Object { $_.Name }
+
+        if ($null -eq $macros) {
+            return @()
+        }
+
+        return @($macros)
+    }
+    catch {
         $errorDetails = $_.Exception.Message
-        Write-Host "Error fetching macros from: $endpointIp. Response: $errorDetails"
+        $message = "Error getting macros from $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
         return @()
     }
 }
 
-# Function to prompt user for confirmation
-function Get-Confirmation {
+# Save macro content to a system
+function Save-SystemMacro {
     param (
-        [string]$promptMessage
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$MacroName,
+        [string]$MacroBody,
+        [string]$LogFile,
+        [string]$SystemName,
+        [string]$NameElement = 'Name',
+        [switch]$IncludeTranspileElement,
+        [string]$TranspileValue = 'False',
+        [switch]$IncludeCommandAttribute
     )
-    Write-Host $promptMessage " (y/n)"
-    $response = Read-Host
-    return $response -eq 'y'
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to upload macro $MacroName to $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $encodedMacro = [System.Security.SecurityElement]::Escape($MacroBody)
+    $commandAttribute = if ($IncludeCommandAttribute.IsPresent) { ' command="True"' } else { '' }
+    $transpileLine = if ($IncludeTranspileElement.IsPresent) { "`n                <Transpile>$TranspileValue</Transpile>" } else { '' }
+
+    $body = @"
+<Command>
+    <Macros>
+        <Macro>
+            <Save$commandAttribute>
+                <$NameElement>$MacroName</$NameElement>
+                <body>$encodedMacro</body>
+                <overWrite>True</overWrite>$transpileLine
+            </Save>
+        </Macro>
+    </Macros>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body
+        $message = "Macro $MacroName uploaded successfully to $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error uploading macro $MacroName to $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Enable a macro on a system
+function Enable-Macro {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$MacroName,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to enable macro $MacroName on $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = @"
+<Command>
+    <Macros>
+        <Macro>
+            <Activate>
+                <name>$MacroName</name>
+            </Activate>
+        </Macro>
+    </Macros>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body
+        $message = "Macro $MacroName enabled successfully on $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error enabling macro $MacroName on $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Enable macros mode on a system
+function Enable-MacrosMode {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to enable macros mode on $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = "<Configuration><Macros><Mode>On</Mode></Macros></Configuration>"
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body -TimeoutSec 10
+        $message = "Macros mode enabled on $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error enabling macros mode on $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Restart macro runtime on a system
+function Restart-MacroRuntime {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to restart macro runtime on $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = @"
+<Command>
+    <Macros>
+        <Runtime>
+            <Restart command="True"/>
+        </Runtime>
+    </Macros>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body
+        $message = "Macro runtime restarted successfully on $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error restarting macro runtime on $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Configure transpile evaluation mode
+function Set-TranspileEvaluation {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$LogFile,
+        [string]$SystemName,
+        [string]$EvaluateTranspiled
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to set transpile evaluation mode to $EvaluateTranspiled on $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = "<Configuration><Macros><EvaluateTranspiled>$EvaluateTranspiled</EvaluateTranspiled></Macros></Configuration>"
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body -TimeoutSec 10
+        $message = "Transpile evaluation mode set to $EvaluateTranspiled on $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        if ($errorDetails -match "Invalid value|Unknown command|Invalid path") {
+            $message = "System $target does not support transpile evaluation settings. Continuing with default configuration."
+            Display-Message $message
+            Log-Message -Message $message -LogFile $LogFile
+            return $true
+        }
+
+        $message = "Error setting transpile evaluation mode on $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Remove a macro from a system
+function Remove-SystemMacro {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$MacroName,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to remove macro $MacroName from $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = @"
+<Command>
+    <Macros>
+        <Macro>
+            <Remove>
+                <Name>$MacroName</Name>
+            </Remove>
+        </Macro>
+    </Macros>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body -TimeoutSec 10
+        $message = "Macro $MacroName removed successfully from $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error removing macro $MacroName from $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Remove a UI extension from a system
+function Remove-UiExtension {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$UiId,
+        [string]$LogFile,
+        [string]$SystemName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $message = "Attempting to remove UI extension $UiId from $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = @"
+<Command>
+    <UserInterface>
+        <Extensions>
+            <Panel>
+                <Remove>
+                    <PanelId>$UiId</PanelId>
+                </Remove>
+            </Panel>
+        </Extensions>
+    </UserInterface>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body -TimeoutSec 10
+        $message = "UI extension $UiId removed successfully from $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error removing UI extension $UiId from $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
+}
+
+# Upload a UI extension definition to a system
+function Save-UiExtension {
+    param (
+        [string]$EndpointIp,
+        [string]$Username,
+        [string]$Password,
+        [string]$PanelContent,
+        [string]$LogFile,
+        [string]$SystemName,
+        [string]$SourceName
+    )
+
+    $target = if ($SystemName) { "$EndpointIp ($SystemName)" } else { $EndpointIp }
+    $panelIdMatch = [regex]::Match($PanelContent, '<PanelId>([^<]+)</PanelId>')
+    $panelId = if ($panelIdMatch.Success) { $panelIdMatch.Groups[1].Value } else { $SourceName }
+
+    $message = "Attempting to upload UI extension $panelId from $SourceName to $target..."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $LogFile
+
+    $body = @"
+<Command>
+    <UserInterface>
+        <Extensions>
+            <Set>
+$PanelContent
+            </Set>
+        </Extensions>
+    </UserInterface>
+</Command>
+"@
+
+    try {
+        Invoke-CiscoXapiRequest -EndpointIp $EndpointIp -Username $Username -Password $Password -Body $body
+        $message = "UI extension $panelId uploaded successfully to $target."
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $true
+    }
+    catch {
+        $errorDetails = $_.Exception.Message
+        $message = "Error uploading UI extension $panelId to $target. Response: $errorDetails"
+        Display-Message $message
+        Log-Message -Message $message -LogFile $LogFile
+        return $false
+    }
 }

--- a/MainMenu.ps1
+++ b/MainMenu.ps1
@@ -9,8 +9,9 @@ while ($true) {
     Write-Host "4. Check macros on a specific system"
     Write-Host "5. Check macros on all systems"
     Write-Host "6. Remove UI extensions"
-    Write-Host "7. Exit"
-    $option = Read-Host "Enter your choice (1, 2, 3, 4, 5, 6, or 7)"
+    Write-Host "7. Upload UI extensions"
+    Write-Host "8. Exit"
+    $option = Read-Host "Enter your choice (1-8)"
 
     switch ($option) {
         "1" {
@@ -32,6 +33,9 @@ while ($true) {
             . .\RemoveUIExtensions.ps1
         }
         "7" {
+            . .\UploadUIExtensions.ps1
+        }
+        "8" {
             Write-Host "Exiting..."
             exit
         }

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ A PowerShell-based utility for managing macros and UI extensions on Cisco video 
   - Optional transpile evaluation configuration
   - Automatic macro mode enabling
   - Supports both modern and legacy Cisco firmware
+- **Upload UI Extensions**: Deploy custom panels/widgets to room devices using exported XML
 - **Remove Macros**: Bulk remove specific macros from systems
 - **Remove UI Extensions**: Clean up UI extensions from systems
 
 ### Secondary Functions
-- **System Checks**: 
+- **System Checks**:
   - Verify macro status on a single system
   - Audit macros across multiple systems
+  - Optional CSV export for audit results
 - **Logging**: Detailed operation logs for troubleshooting
 
 ### Recent Updates
@@ -75,13 +77,14 @@ The tool uses `-SkipCertificateCheck` when connecting to systems to handle self-
    .\MainMenu.ps1
    ```
 3. Choose from the available options:
-   - 1: Upload Pexip OTJ macros
-   - 2: Upload .js macros
-   - 3: Remove macros
-   - 4: Check macros on a specific system
-   - 5: Check macros on all systems
-   - 6: Remove UI extensions
-   - 7: Exit
+  - 1: Upload Pexip OTJ macros
+  - 2: Upload .js macros
+  - 3: Remove macros
+  - 4: Check macros on a specific system (optional CSV export)
+  - 5: Check macros on all systems (optional CSV export)
+  - 6: Remove UI extensions
+  - 7: Upload UI extensions
+  - 8: Exit
 
 ## 📊 Logging
 

--- a/RemoveMacros.ps1
+++ b/RemoveMacros.ps1
@@ -1,149 +1,42 @@
 # Source helper functions
 . .\HelperFunctions.ps1
 
-# Function to log messages to a file
-function Log-Message {
-    param (
-        [string]$message,
-        [string]$logFile
-    )
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp - $message"
-    Add-Content -Path $logFile -Value $logEntry
-}
-
-# Function to display messages in the console
-function Display-Message {
-    param (
-        [string]$message
-    )
-    Write-Host $message
-}
-
 # Initialize log file
 $logFile = "RemoveMacros.log"
 
 Display-Message "Option 3 selected: Remove macros"
-Log-Message -message "Option 3 selected: Remove macros" -logFile $logFile
+Log-Message -Message "Option 3 selected: Remove macros" -LogFile $logFile
 
 # Prompt user for CSV file path
 $csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CSV file:"
 
 # Prompt user for the macros to remove
 $macrosToRemove = Read-Host "Please enter the macros to remove (comma separated):"
-$macrosToRemoveArray = $macrosToRemove -split ',' | ForEach-Object { $_.Trim() }
+$macrosToRemoveArray = $macrosToRemove -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+
+if ($macrosToRemoveArray.Count -eq 0) {
+    Display-Message "No macros specified for removal."
+    Log-Message -Message "No macros specified for removal." -LogFile $logFile
+    return
+}
 
 # Import CSV
 try {
-    $systems = @(Import-Csv -Path $csvFilePath) 
-    if ($systems -eq $null -or $systems.Count -eq 0) {
-        throw "CSV file is empty or improperly formatted."
-    }
+    $systems = Import-SystemCsv -Path $csvFilePath
     Display-Message "Found $($systems.Count) systems in the CSV file."
-    Log-Message -message "Found $($systems.Count) systems in the CSV file." -logFile $logFile
+    Log-Message -Message "Found $($systems.Count) systems in the CSV file." -LogFile $logFile
 } catch {
     $errorDetails = $_.Exception.Message
     Display-Message "Error importing CSV file. Response: $errorDetails"
-    Log-Message -message "Error importing CSV file. Response: $errorDetails" -logFile $logFile
+    Log-Message -Message "Error importing CSV file. Response: $errorDetails" -LogFile $logFile
     return
 }
 
 # Confirm removal
 if (-not (Get-Confirmation -promptMessage "Do you want to proceed with the removal?")) {
     Display-Message "Removal cancelled."
-    Log-Message -message "Removal cancelled." -logFile $logFile
+    Log-Message -Message "Removal cancelled." -LogFile $logFile
     return
-}
-
-# Function to get macros from a system
-function Get-Macros {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to get macros from $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Content-Type", "application/xml")
-    $headers.Add("Authorization", "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}")))
-
-    $body = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Get/>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://${endpointIp}/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        [xml]$xmlResponse = $response
-        $macros = $xmlResponse.Command.MacroGetResult.Macro | ForEach-Object { $_.Name }
-        $message = "Macros on ${endpointIp} ($systemName): $($macros -join ', ')"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $macros
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error getting macros from ${endpointIp} ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return @()
-    }
-}
-
-# Function to remove a macro from a system
-function Remove-Macro {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$macroName,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to remove macro $macroName from ${endpointIp} ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Content-Type", "application/xml")
-    $headers.Add("Authorization", "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}")))
-
-    $body = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Remove>
-                <Name>$macroName</Name>
-            </Remove>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://${endpointIp}/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        $message = "Macro $macroName removed successfully from ${endpointIp} ($systemName)."
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $true
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error removing macro $macroName from ${endpointIp} ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $false
-    }
 }
 
 # Perform the removal
@@ -155,19 +48,19 @@ foreach ($system in $systems) {
     $username = $system.'username'
     $password = $system.'password'
 
-    $macros = Get-Macros -endpointIp $ipAddress -username $username -password $password -logFile $logFile -systemName $systemName
+    $macros = Get-SystemMacros -EndpointIp $ipAddress -Username $username -Password $password -LogFile $logFile -SystemName $systemName
 
     $systemSummary = [PSCustomObject]@{
-        IPAddress = $ipAddress
-        SystemName = $systemName
-        TotalMacros = $macrosToRemoveArray.Count
+        IPAddress         = $ipAddress
+        SystemName        = $systemName
+        TotalMacros       = $macrosToRemoveArray.Count
         SuccessfulRemovals = 0
-        FailedRemovals = 0
+        FailedRemovals     = 0
     }
 
     foreach ($macro in $macrosToRemoveArray) {
         if ($macros -contains $macro) {
-            $success = Remove-Macro -endpointIp $ipAddress -username $username -password $password -macroName $macro -logFile $logFile -systemName $systemName
+            $success = Remove-SystemMacro -EndpointIp $ipAddress -Username $username -Password $password -MacroName $macro -LogFile $logFile -SystemName $systemName
             if ($success) {
                 $systemSummary.SuccessfulRemovals++
             } else {
@@ -176,7 +69,7 @@ foreach ($system in $systems) {
         } else {
             $message = "Macro $macro not found on ${ipAddress} ($systemName)."
             Display-Message $message
-            Log-Message -message $message -logFile $logFile
+            Log-Message -Message $message -LogFile $logFile
             $systemSummary.FailedRemovals++
         }
     }
@@ -190,22 +83,22 @@ $partialSystems = $removalSummary | Where-Object { $_.SuccessfulRemovals -gt 0 -
 $failedSystems = $removalSummary | Where-Object { $_.SuccessfulRemovals -eq 0 }
 
 Display-Message "Removal completed."
-Log-Message -message "Removal completed." -logFile $logFile
+Log-Message -Message "Removal completed." -LogFile $logFile
 
 if ($successfulSystems.Count -gt 0) {
     $message = "Successfully removed all specified macros from $($successfulSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($partialSystems.Count -gt 0) {
     $message = "Partially removed some macros from $($partialSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($failedSystems.Count -gt 0) {
     $message = "$($failedSystems.Count) systems were unsuccessful for removing any macros."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }

--- a/RemoveUIExtensions.ps1
+++ b/RemoveUIExtensions.ps1
@@ -1,107 +1,42 @@
 # Source helper functions
 . .\HelperFunctions.ps1
 
-# Function to log messages to a file
-function Log-Message {
-    param (
-        [string]$message,
-        [string]$logFile
-    )
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp - $message"
-    Add-Content -Path $logFile -Value $logEntry
-}
-
-# Function to display messages in the console
-function Display-Message {
-    param (
-        [string]$message
-    )
-    Write-Host $message
-}
-
 # Initialize log file
 $logFile = "RemoveUIExtensions.log"
 
 Display-Message "Option 6 selected: Remove UI extensions"
-Log-Message -message "Option 6 selected: Remove UI extensions" -logFile $logFile
+Log-Message -Message "Option 6 selected: Remove UI extensions" -LogFile $logFile
 
 # Prompt user for CSV file path
 $csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CSV file:"
 
 # Prompt user for the UI IDs to remove
 $uiIdsToRemove = Read-Host "Please enter the UI IDs to remove (comma separated):"
-$uiIdsToRemoveArray = $uiIdsToRemove -split ',' | ForEach-Object { $_.Trim() }
+$uiIdsToRemoveArray = $uiIdsToRemove -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+
+if ($uiIdsToRemoveArray.Count -eq 0) {
+    Display-Message "No UI extensions specified for removal."
+    Log-Message -Message "No UI extensions specified for removal." -LogFile $logFile
+    return
+}
 
 # Import CSV
 try {
-    $systems = @(Import-Csv -Path $csvFilePath)
-    if ($systems -eq $null -or $systems.Count -eq 0) {
-        throw "CSV file is empty or improperly formatted."
-    }
+    $systems = Import-SystemCsv -Path $csvFilePath
     Display-Message "Found $($systems.Count) systems in the CSV file."
-    Log-Message -message "Found $($systems.Count) systems in the CSV file." -logFile $logFile
+    Log-Message -Message "Found $($systems.Count) systems in the CSV file." -LogFile $logFile
 } catch {
     $errorDetails = $_.Exception.Message
     Display-Message "Error importing CSV file. Response: $errorDetails"
-    Log-Message -message "Error importing CSV file. Response: $errorDetails" -logFile $logFile
+    Log-Message -Message "Error importing CSV file. Response: $errorDetails" -LogFile $logFile
     return
 }
 
 # Confirm removal
 if (-not (Get-Confirmation -promptMessage "Do you want to proceed with the removal?")) {
     Display-Message "Removal cancelled."
-    Log-Message -message "Removal cancelled." -logFile $logFile
+    Log-Message -Message "Removal cancelled." -LogFile $logFile
     return
-}
-
-# Function to remove a UI extension from a system
-function Remove-UIExtension {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$uiId,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to remove UI extension $uiId from ${endpointIp} ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $body = @"
-<Command>
-    <UserInterface>
-        <Extensions>
-            <Panel>
-                <Remove>
-                    <PanelId>$uiId</PanelId>
-                </Remove>
-            </Panel>
-        </Extensions>
-    </UserInterface>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://${endpointIp}/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        $message = "UI extension $uiId removed successfully from ${endpointIp} ($systemName)."
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $true
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error removing UI extension $uiId from ${endpointIp} ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $false
-    }
 }
 
 # Perform the removal
@@ -114,15 +49,15 @@ foreach ($system in $systems) {
     $password = $system.'password'
 
     $systemSummary = [PSCustomObject]@{
-        IPAddress = $ipAddress
-        SystemName = $systemName
-        TotalUIExtensions = $uiIdsToRemoveArray.Count
+        IPAddress          = $ipAddress
+        SystemName         = $systemName
+        TotalUIExtensions  = $uiIdsToRemoveArray.Count
         SuccessfulRemovals = 0
-        FailedRemovals = 0
+        FailedRemovals     = 0
     }
 
     foreach ($uiId in $uiIdsToRemoveArray) {
-        $success = Remove-UIExtension -endpointIp $ipAddress -username $username -password $password -uiId $uiId -logFile $logFile -systemName $systemName
+        $success = Remove-UiExtension -EndpointIp $ipAddress -Username $username -Password $password -UiId $uiId -LogFile $logFile -SystemName $systemName
         if ($success) {
             $systemSummary.SuccessfulRemovals++
         } else {
@@ -139,22 +74,22 @@ $partialSystems = $removalSummary | Where-Object { $_.SuccessfulRemovals -gt 0 -
 $failedSystems = $removalSummary | Where-Object { $_.SuccessfulRemovals -eq 0 }
 
 Display-Message "Removal completed."
-Log-Message -message "Removal completed." -logFile $logFile
+Log-Message -Message "Removal completed." -LogFile $logFile
 
 if ($successfulSystems.Count -gt 0) {
     $message = "Successfully removed all specified UI extensions from $($successfulSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($partialSystems.Count -gt 0) {
     $message = "Partially removed some UI extensions from $($partialSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($failedSystems.Count -gt 0) {
     $message = "$($failedSystems.Count) systems were unsuccessful for removing any UI extensions."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }

--- a/UploadJsMacros.ps1
+++ b/UploadJsMacros.ps1
@@ -1,30 +1,11 @@
 # Source helper functions
 . .\HelperFunctions.ps1
 
-# Function to log messages to a file
-function Log-Message {
-    param (
-        [string]$message,
-        [string]$logFile
-    )
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $logEntry = "$timestamp - $message"
-    Add-Content -Path $logFile -Value $logEntry
-}
-
-# Function to display messages in the console
-function Display-Message {
-    param (
-        [string]$message
-    )
-    Write-Host $message
-}
-
 # Initialize log file
 $logFile = "UploadJsMacros.log"
 
 Display-Message "Option 2 selected: Upload .js macros"
-Log-Message -message "Option 2 selected: Upload .js macros" -logFile $logFile
+Log-Message -Message "Option 2 selected: Upload .js macros" -LogFile $logFile
 
 # Prompt user for CSV file path
 $csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CSV file:"
@@ -33,22 +14,26 @@ $csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CS
 $jsDirectory = Get-FilePath -promptMessage "Please enter the full path to the directory containing the .js files:"
 
 # List .js files
-$jsFiles = Get-ChildItem -Path $jsDirectory -Filter *.js
+$jsFiles = Get-ChildItem -Path $jsDirectory -Filter *.js -ErrorAction SilentlyContinue
+
+if ($jsFiles.Count -eq 0) {
+    Display-Message "No .js files were found in the specified directory."
+    Log-Message -Message "No .js files were found in the directory $jsDirectory." -LogFile $logFile
+    return
+}
+
 Display-Message "Found $($jsFiles.Count) .js files in the directory."
-Log-Message -message "Found $($jsFiles.Count) .js files in the directory." -logFile $logFile
+Log-Message -Message "Found $($jsFiles.Count) .js files in the directory." -LogFile $logFile
 
 # Import CSV
 try {
-    $systems = @(Import-Csv -Path $csvFilePath)
-    if ($systems -eq $null -or $systems.Count -eq 0) {
-        throw "CSV file is empty or improperly formatted."
-    }
+    $systems = Import-SystemCsv -Path $csvFilePath
     Display-Message "Found $($systems.Count) systems in the CSV file."
-    Log-Message -message "Found $($systems.Count) systems in the CSV file." -logFile $logFile
+    Log-Message -Message "Found $($systems.Count) systems in the CSV file." -LogFile $logFile
 } catch {
     $errorDetails = $_.Exception.Message
     Display-Message "Error importing CSV file. Response: $errorDetails"
-    Log-Message -message "Error importing CSV file. Response: $errorDetails" -logFile $logFile
+    Log-Message -Message "Error importing CSV file. Response: $errorDetails" -LogFile $logFile
     return
 }
 
@@ -67,236 +52,8 @@ if ([string]::IsNullOrWhiteSpace($option) -or $option -eq "no" -or $option -eq "
 # Confirm upload
 if (-not (Get-Confirmation -promptMessage "Do you want to proceed with the upload?")) {
     Display-Message "Upload cancelled."
-    Log-Message -message "Upload cancelled." -logFile $logFile
+    Log-Message -Message "Upload cancelled." -LogFile $logFile
     return
-}
-
-# Function to upload macros from a .js file
-function Upload-MacroFromJs {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$jsFilePath,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $macroName = [System.IO.Path]::GetFileNameWithoutExtension($jsFilePath)
-    $jsCode = Get-Content -Path $jsFilePath -Raw
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $encodedJsCode = [System.Security.SecurityElement]::Escape($jsCode)
-
-    $bodyTemplate = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Save>
-                <Name>$macroName</Name>
-                <body>$encodedJsCode</body>
-                <overWrite>True</overWrite>
-            </Save>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    $body = $bodyTemplate
-    $bodyBytes = [Text.Encoding]::UTF8.GetBytes($body)
-
-    $headers["Content-Length"] = $bodyBytes.Length
-
-    $message = "Attempting to upload macro from $jsFilePath to $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $bodyBytes -TimeoutSec 15 -SkipCertificateCheck
-        $message = "Macro $macroName uploaded successfully to $endpointIp ($systemName) from $jsFilePath."
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-
-        # Enable the uploaded macro
-        Enable-Macro -endpointIp $endpointIp -username $username -password $password -macroName $macroName -logFile $logFile -systemName $systemName
-
-        return $true
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error uploading macro $macroName to: $endpointIp ($systemName) from $jsFilePath. Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $false
-    }
-}
-
-# Function to enable a macro on a system
-function Enable-Macro {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$macroName,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to enable macro $macroName on $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $body = @"
-<Command>
-    <Macros>
-        <Macro>
-            <Activate>
-                <name>$macroName</name>
-            </Activate>
-        </Macro>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 15 -SkipCertificateCheck
-        $message = "Macro $macroName enabled successfully on $endpointIp ($systemName)."
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error enabling macro $macroName on $endpointIp ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    }
-}
-
-# Function to enable macros mode
-function Enable-MacrosMode {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to enable macros mode on $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $body = "<Configuration><Macros><Mode>On</Mode></Macros></Configuration>"
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        $message = "Macros mode enabled on $endpointIp ($systemName)"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error enabling macros mode on $endpointIp ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    }
-}
-
-# Function to restart macro runtime
-function Restart-MacroRuntime {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile,
-        [string]$systemName
-    )
-
-    $message = "Attempting to restart macro runtime on $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $body = @"
-<Command>
-    <Macros>
-        <Runtime>
-            <Restart command="True"/>
-        </Runtime>
-    </Macros>
-</Command>
-"@
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 15 -SkipCertificateCheck
-        $message = "Macro runtime restarted successfully on $endpointIp ($systemName)."
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    } catch {
-        $errorDetails = $_.Exception.Message
-        $message = "Error restarting macro runtime on $endpointIp ($systemName). Response: $errorDetails"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-    }
-}
-
-# Function to set transpile evaluation mode
-function Set-TranspileEvaluation {
-    param (
-        [string]$endpointIp,
-        [string]$username,
-        [string]$password,
-        [string]$logFile,
-        [string]$systemName,
-        [string]$evaluateTranspiled
-    )
-
-    $message = "Attempting to set transpile evaluation mode to $evaluateTranspiled on $endpointIp ($systemName)..."
-    Display-Message $message
-    Log-Message -message $message -logFile $logFile
-
-    $headers = @{
-        "Content-Type"  = "application/xml"
-        "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
-    }
-
-    $body = "<Configuration><Macros><EvaluateTranspiled>$evaluateTranspiled</EvaluateTranspiled></Macros></Configuration>"
-
-    try {
-        $response = Invoke-RestMethod -Uri "https://$endpointIp/putxml" -Method 'POST' -Headers $headers -Body $body -TimeoutSec 10 -SkipCertificateCheck
-        $message = "Transpile evaluation mode set to $evaluateTranspiled on $endpointIp ($systemName)"
-        Display-Message $message
-        Log-Message -message $message -logFile $logFile
-        return $true
-    } catch {
-        $errorDetails = $_.Exception.Message
-        if ($errorDetails -match "Invalid value|Unknown command|Invalid path") {
-            $message = "System $endpointIp ($systemName) does not support transpile evaluation settings. Continuing with default configuration."
-            Display-Message $message
-            Log-Message -message $message -logFile $logFile
-            return $true
-        } else {
-            $message = "Error setting transpile evaluation mode on $endpointIp ($systemName). Response: $errorDetails"
-            Display-Message $message
-            Log-Message -message $message -logFile $logFile
-            return $false
-        }
-    }
 }
 
 # Perform the upload
@@ -308,36 +65,48 @@ foreach ($system in $systems) {
     $username = $system.'username'
     $password = $system.'password'
 
-    # Enable macros mode once per system before any operations
-    Enable-MacrosMode -endpointIp $ipAddress -username $username -password $password -logFile $logFile -systemName $systemName
+    Enable-MacrosMode -EndpointIp $ipAddress -Username $username -Password $password -LogFile $logFile -SystemName $systemName | Out-Null
 
-    # Set transpile evaluation mode
-    $transpileSuccess = Set-TranspileEvaluation -endpointIp $ipAddress -username $username -password $password -logFile $logFile -systemName $systemName -evaluateTranspiled $evaluateTranspiled
+    $transpileSuccess = Set-TranspileEvaluation -EndpointIp $ipAddress -Username $username -Password $password -LogFile $logFile -SystemName $systemName -EvaluateTranspiled $evaluateTranspiled
     if (-not $transpileSuccess) {
         Display-Message "Skipping uploads for $ipAddress ($systemName) due to configuration error"
+        Log-Message -Message "Skipping uploads for $ipAddress ($systemName) due to configuration error" -LogFile $logFile
         continue
     }
 
     $systemSummary = [PSCustomObject]@{
-        IPAddress = $ipAddress
-        SystemName = $systemName
-        TotalFiles = $jsFiles.Count
+        IPAddress         = $ipAddress
+        SystemName        = $systemName
+        TotalFiles        = $jsFiles.Count
         SuccessfulUploads = 0
-        FailedUploads = 0
+        FailedUploads     = 0
     }
 
     foreach ($jsFile in $jsFiles) {
-        # Upload macro
-        $success = Upload-MacroFromJs -endpointIp $ipAddress -username $username -password $password -jsFilePath $jsFile.FullName -logFile $logFile -systemName $systemName
-        if ($success) {
+        try {
+            $jsCode = Get-Content -Path $jsFile.FullName -Raw -ErrorAction Stop
+        } catch {
+            $errorDetails = $_.Exception.Message
+            $message = "Error reading file $($jsFile.FullName). Response: $errorDetails"
+            Display-Message $message
+            Log-Message -Message $message -LogFile $logFile
+            $systemSummary.FailedUploads++
+            continue
+        }
+
+        $macroName = [System.IO.Path]::GetFileNameWithoutExtension($jsFile.Name)
+        $saveSuccess = Save-SystemMacro -EndpointIp $ipAddress -Username $username -Password $password -MacroName $macroName -MacroBody $jsCode -LogFile $logFile -SystemName $systemName
+
+        if ($saveSuccess) {
             $systemSummary.SuccessfulUploads++
+            Enable-Macro -EndpointIp $ipAddress -Username $username -Password $password -MacroName $macroName -LogFile $logFile -SystemName $systemName | Out-Null
         } else {
             $systemSummary.FailedUploads++
         }
     }
 
     if ($systemSummary.SuccessfulUploads -gt 0) {
-        Restart-MacroRuntime -endpointIp $ipAddress -username $username -password $password -logFile $logFile -systemName $systemName
+        Restart-MacroRuntime -EndpointIp $ipAddress -Username $username -Password $password -LogFile $logFile -SystemName $systemName | Out-Null
     }
 
     $uploadSummary += $systemSummary
@@ -349,22 +118,22 @@ $partialSystems = $uploadSummary | Where-Object { $_.SuccessfulUploads -gt 0 -an
 $failedSystems = $uploadSummary | Where-Object { $_.SuccessfulUploads -eq 0 }
 
 Display-Message "Upload completed."
-Log-Message -message "Upload completed." -logFile $logFile
+Log-Message -Message "Upload completed." -LogFile $logFile
 
 if ($successfulSystems.Count -gt 0) {
     $message = "Successfully uploaded all macros to $($successfulSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($partialSystems.Count -gt 0) {
     $message = "Partially uploaded some macros to $($partialSystems.Count) systems."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }
 
 if ($failedSystems.Count -gt 0) {
     $message = "$($failedSystems.Count) systems were unsuccessful for all macros."
     Display-Message $message
-    Log-Message -message $message -logFile $logFile
+    Log-Message -Message $message -LogFile $logFile
 }

--- a/UploadUIExtensions.ps1
+++ b/UploadUIExtensions.ps1
@@ -1,0 +1,113 @@
+# Source helper functions
+. .\HelperFunctions.ps1
+
+# Initialize log file
+$logFile = "UploadUIExtensions.log"
+
+Display-Message "Option 7 selected: Upload UI extensions"
+Log-Message -Message "Option 7 selected: Upload UI extensions" -LogFile $logFile
+
+# Prompt user for CSV file path
+$csvFilePath = Get-FilePath -promptMessage "Please enter the full path to the CSV file:"
+
+# Prompt user for the directory containing UI extension files
+$panelDirectory = Get-FilePath -promptMessage "Please enter the full path to the directory containing the UI extension XML files:"
+
+# List UI extension files
+$panelFiles = Get-ChildItem -Path $panelDirectory -Filter *.xml -ErrorAction SilentlyContinue
+
+if ($panelFiles.Count -eq 0) {
+    Display-Message "No UI extension XML files were found in the specified directory."
+    Log-Message -Message "No UI extension XML files were found in the directory $panelDirectory." -LogFile $logFile
+    return
+}
+
+Display-Message "Found $($panelFiles.Count) UI extension files in the directory."
+Log-Message -Message "Found $($panelFiles.Count) UI extension files in the directory." -LogFile $logFile
+
+# Import CSV
+try {
+    $systems = Import-SystemCsv -Path $csvFilePath
+    Display-Message "Found $($systems.Count) systems in the CSV file."
+    Log-Message -Message "Found $($systems.Count) systems in the CSV file." -LogFile $logFile
+} catch {
+    $errorDetails = $_.Exception.Message
+    Display-Message "Error importing CSV file. Response: $errorDetails"
+    Log-Message -Message "Error importing CSV file. Response: $errorDetails" -LogFile $logFile
+    return
+}
+
+# Confirm upload
+if (-not (Get-Confirmation -promptMessage "Do you want to proceed with uploading UI extensions?")) {
+    Display-Message "Upload cancelled."
+    Log-Message -Message "Upload cancelled." -LogFile $logFile
+    return
+}
+
+# Perform the upload
+$uploadSummary = @()
+
+foreach ($system in $systems) {
+    $systemName = $system.'system name'
+    $ipAddress = $system.'ip address'
+    $username = $system.'username'
+    $password = $system.'password'
+
+    $systemSummary = [PSCustomObject]@{
+        IPAddress         = $ipAddress
+        SystemName        = $systemName
+        TotalExtensions   = $panelFiles.Count
+        SuccessfulUploads = 0
+        FailedUploads     = 0
+    }
+
+    foreach ($panelFile in $panelFiles) {
+        try {
+            $panelContent = Get-Content -Path $panelFile.FullName -Raw -ErrorAction Stop
+            $panelContent = [System.Text.RegularExpressions.Regex]::Replace($panelContent, '^\s*<\?xml.*?\?>\s*', '', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+        } catch {
+            $errorDetails = $_.Exception.Message
+            $message = "Error reading file $($panelFile.FullName). Response: $errorDetails"
+            Display-Message $message
+            Log-Message -Message $message -LogFile $logFile
+            $systemSummary.FailedUploads++
+            continue
+        }
+
+        $success = Save-UiExtension -EndpointIp $ipAddress -Username $username -Password $password -PanelContent $panelContent -LogFile $logFile -SystemName $systemName -SourceName $panelFile.Name
+
+        if ($success) {
+            $systemSummary.SuccessfulUploads++
+        } else {
+            $systemSummary.FailedUploads++
+        }
+    }
+
+    $uploadSummary += $systemSummary
+}
+
+# Generate summary
+$successfulSystems = $uploadSummary | Where-Object { $_.SuccessfulUploads -eq $_.TotalExtensions }
+$partialSystems = $uploadSummary | Where-Object { $_.SuccessfulUploads -gt 0 -and $_.SuccessfulUploads -lt $_.TotalExtensions }
+$failedSystems = $uploadSummary | Where-Object { $_.SuccessfulUploads -eq 0 }
+
+Display-Message "UI extension upload completed."
+Log-Message -Message "UI extension upload completed." -LogFile $logFile
+
+if ($successfulSystems.Count -gt 0) {
+    $message = "Successfully uploaded all UI extensions to $($successfulSystems.Count) systems."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $logFile
+}
+
+if ($partialSystems.Count -gt 0) {
+    $message = "Partially uploaded some UI extensions to $($partialSystems.Count) systems."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $logFile
+}
+
+if ($failedSystems.Count -gt 0) {
+    $message = "$($failedSystems.Count) systems were unsuccessful for all UI extensions."
+    Display-Message $message
+    Log-Message -Message $message -LogFile $logFile
+}


### PR DESCRIPTION
## Summary
- centralize logging, authentication, and xAPI helpers for macros and UI extensions so each script reuses the same request logic
- refactor macro upload/removal/check scripts to use the shared helpers and add optional CSV export when auditing macros
- add a UI extension upload workflow, expose it in the main menu, and document the new capability in the README

## Testing
- ⚠️ `pwsh --version` *(PowerShell is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca41526cac8323bcdfa62f5fbe27af